### PR TITLE
Refactor WordPress download url to point to official stable version.

### DIFF
--- a/bin/homepress.js
+++ b/bin/homepress.js
@@ -54,7 +54,7 @@ switch(command) {
 
   default:
     console.log("You didn't supply a proper command.");
-    console.log("Use on of these: " + [
+    console.log("Use one of these: " + [
       "start",
       "init",
       "wp-update",
@@ -64,4 +64,3 @@ switch(command) {
   break;
 
 }
-

--- a/bin/wordpress.js
+++ b/bin/wordpress.js
@@ -32,7 +32,7 @@ module.exports = function(callback) {
       'xmlrpc.php',
   ];
 
-  // don't bother using node's unlink 
+  // don't bother using node's unlink
   // since it can't handle non empty directories
   files.map(file => {execSync(`rm -rf ${path.join(pwd, file)}`)});
 
@@ -44,7 +44,7 @@ module.exports = function(callback) {
 
   // Downloading WordPress
 
-  download('https://github.com/WordPress/WordPress/archive/master.zip', zipFile, err => {
+  download('https://wordpress.org/latest.zip', zipFile, err => {
 
     console.log("Installing WordPress...");
     var zip = new AdmZip(zipFile);


### PR DESCRIPTION
The previous download operation pointed to WordPress' GitHub mirror. This meant that downloads were of the unstable version. Now, Homepress will download the stable version from the official site instead.
